### PR TITLE
Possible typo in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ use async_std::net::TcpStream;
 
 let tcp_stream = TcpStream::connect("rust-lang.org:443").await?;
 let connector = TlsConnector::default();
-let handshake = connector::connect("www.rust-lang.org", tcp_stream)?;
+let handshake = connector.connect("www.rust-lang.org", tcp_stream)?;
 let mut tls_stream = handshake.await?;
 
 // ...


### PR DESCRIPTION
I believe you want write `connector.connect(...)`, not `connector::connect(...)`. 

I was initially confused because `connector` is a value but `::connect` makes it look like it's a type.