### PR TITLE
Don't return a io::Result<impl Future<_>> from Connector::connect() b…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ use async_std::net::TcpStream;
 
 let tcp_stream = TcpStream::connect("rust-lang.org:443").await?;
 let connector = TlsConnector::default();
-let handshake = connector.connect("www.rust-lang.org", tcp_stream)?;
-let mut tls_stream = handshake.await?;
+let mut tls_stream = connector.connect("www.rust-lang.org", tcp_stream).await?;
 
 // ...
 ```

--- a/examples/client/src/main.rs
+++ b/examples/client/src/main.rs
@@ -63,13 +63,10 @@ fn main() -> io::Result<()> {
         let tcp_stream = TcpStream::connect(&addr).await?;
 
         // Use the connector to start the handshake process.
-        // This might fail early if you pass an invalid domain,
-        // which is why we use `?`.
         // This consumes the TCP stream to ensure you are not reusing it.
-        let handshake = connector.connect(&domain, tcp_stream)?;
         // Awaiting the handshake gives you an encrypted
         // stream back which you can use like any other.
-        let mut tls_stream = handshake.await?;
+        let mut tls_stream = connector.connect(&domain, tcp_stream).await?;
 
         // We write our crafted HTTP request to it
         tls_stream.write_all(http_request.as_bytes()).await?;

--- a/src/test_0rtt.rs
+++ b/src/test_0rtt.rs
@@ -19,7 +19,7 @@ async fn get(
     let mut buf = Vec::new();
 
     let stream = TcpStream::connect(&addr).await?;
-    let mut stream = connector.connect(domain, stream)?.await?;
+    let mut stream = connector.connect(domain, stream).await?;
     stream.write_all(input.as_bytes()).await?;
     stream.read_to_end(&mut buf).await?;
 

--- a/tests/google.rs
+++ b/tests/google.rs
@@ -9,7 +9,7 @@ fn fetch_google() -> std::io::Result<()> {
         let connector = TlsConnector::default();
 
         let stream = TcpStream::connect("google.com:443").await?;
-        let mut stream = connector.connect("google.com", stream)?.await?;
+        let mut stream = connector.connect("google.com", stream).await?;
 
         stream.write_all(b"GET / HTTP/1.0\r\n\r\n").await?;
         let mut res = vec![];

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -67,7 +67,7 @@ async fn start_client(addr: SocketAddr, domain: &str, config: Arc<ClientConfig>)
     let mut buf = vec![0; FILE.len()];
 
     let stream = TcpStream::connect(&addr).await?;
-    let mut stream = config.connect(domain, stream)?.await?;
+    let mut stream = config.connect(domain, stream).await?;
     stream.write_all(FILE).await?;
     stream.read_exact(&mut buf).await?;
 


### PR DESCRIPTION
…ut only a plain future

`let conn = connector.connect(...)?.await?` is a bit awkward to use
because of the double ?-operator. Instead always return a future now
that in case of domain format errors immediately resolves to the error.

https://github.com/async-rs/async-tls/issues/10

----

Note: This changes the API and requires a new major release!