### PR TITLE
fix: expose intermediate future types

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,3 +1,5 @@
+//! The client end of a TLS connection.
+
 use crate::common::tls_state::TlsState;
 use crate::rusttls::stream::Stream;
 use futures::io::{AsyncRead, AsyncWrite};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ mod connector;
 mod rusttls;
 pub mod server;
 
-pub use acceptor::TlsAcceptor;
-pub use connector::TlsConnector;
+pub use acceptor::{Accept, TlsAcceptor};
+pub use connector::{Connect, TlsConnector};
 
 #[cfg(feature = "early-data")]
 #[cfg(test)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,3 +1,5 @@
+//! The server end of a TLS connection.
+
 use crate::common::tls_state::TlsState;
 use crate::rusttls::stream::Stream;
 


### PR DESCRIPTION
Exposes the intermediate futures. Was looking at the docs, and was confused about the anonymous types returned by `connect` / `accept`. This should make it a lot clearer. Thanks!