### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ travis-ci = { repository = "async-std/async-tls" }
 appveyor = { repository = "async-std/async-tls" }
 
 [dependencies]
-futures = "0.3"
-rustls = "0.16"
-webpki = "0.21"
-webpki-roots = "0.17"
+futures = "0.3.4"
+rustls = "0.17.0"
+webpki = "0.21.2"
+webpki-roots = "0.19.0"
 
 [features]
 early-data = []

--- a/examples/client/Cargo.toml
+++ b/examples/client/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The async-rs authors", "quininer <quininer@live.com>"]
 edition = "2018"
 
 [dependencies]
-structopt = "0.2"
-rustls    = "0.16"
-async-std = "0.99"
+structopt = "0.3.9"
+rustls    = "0.17.0"
+async-std = "1.5.0"
 async-tls = { path = "../.." }

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["The async-rs developers", "quininer <quininer@live.com>"]
 edition = "2018"
 
 [dependencies]
-structopt = "0.2"
-async-std = "0.99"
+structopt = "0.3.9"
+async-std = "1.5.0"
 async-tls = { path = "../.." }
-rustls = "0.16"
-webpki = "0.21"
+rustls = "0.17.0"
+webpki = "0.21.2"


### PR DESCRIPTION
This bumps all dependencies to the latest versions. If preferred, I
could bump only `rustls` and `webpki-roots`.