### PR TITLE
Public ClientSession

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -40,6 +40,10 @@ impl<IO> TlsStream<IO> {
     pub fn get_mut(&mut self) -> &mut IO {
         &mut self.io
     }
+
+    pub fn get_session_ref(&self) -> &ClientSession {
+        &self.session
+    }
 }
 
 impl<IO> Future for MidHandshake<IO>


### PR DESCRIPTION
Hi there

Sometimes, we want to get server certificate information(e.g. expire date), and [rustls get_peer_certificates](https://docs.rs/rustls/0.17.0/rustls/trait.Session.html#tymethod.get_peer_certificates) can get it. maybe we can public it.

Please review it. thank you.



