### PR TITLE
Add cargo features "client" and "server"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
 script:
     - cargo test
     - cargo test --features early-data
+    - cargo test ---no-default-features --features client
+    - cargo test ---no-default-features --features server
     - cd examples/server
     - cargo check
     - cd ../../examples/client

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,24 @@ appveyor = { repository = "async-std/async-tls" }
 [dependencies]
 futures = "0.3.4"
 rustls = "0.17.0"
-webpki = "0.21.2"
-webpki-roots = "0.19.0"
+webpki = { version = "0.21.2", optional = true }
+webpki-roots = { version = "0.19.0", optional = true }
 
 [features]
+default = ["client", "server"]
+client = ["webpki", "webpki-roots"]
 early-data = []
+server = []
 
 [dev-dependencies]
 lazy_static = "1"
 futures-util = "0.3"
 async-std = { version = "1.0", features = ["unstable"] }
+
+[[test]]
+name = "test"
+required-features = ["client", "server"]
+
+[[test]]
+name = "google"
+required-features = ["client"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,16 +2,21 @@
 
 #![deny(unsafe_code)]
 
+#[cfg(feature = "server")]
 mod acceptor;
+#[cfg(feature = "client")]
 pub mod client;
 mod common;
+#[cfg(feature = "client")]
 mod connector;
 mod rusttls;
+#[cfg(feature = "server")]
 pub mod server;
 
+#[cfg(feature = "server")]
 pub use acceptor::{Accept, TlsAcceptor};
+#[cfg(feature = "client")]
 pub use connector::{Connect, TlsConnector};
 
-#[cfg(feature = "early-data")]
-#[cfg(test)]
+#[cfg(all(test, feature = "client", feature = "early-data"))]
 mod test_0rtt;

--- a/src/rusttls/stream.rs
+++ b/src/rusttls/stream.rs
@@ -257,6 +257,6 @@ impl<'a, IO: AsyncRead + AsyncWrite + Unpin, S: Session> AsyncWrite for Stream<'
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "client"))]
 #[path = "test_stream.rs"]
 mod test_stream;


### PR DESCRIPTION
Since many consumers of this library do not need both client and server features, this allows them to shrink their dependencies somewhat.

In particular, server applications would no longer need to build the unused <del>webpki and</del> webpki-roots crate.

I would also suggest making these features disabled by default in a future version, to increase the likeliness that consumers will choose the features they actually need. (This would be a breaking change.)