### PR TITLE
finer-grained dependencies on futures crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ travis-ci = { repository = "async-std/async-tls" }
 appveyor = { repository = "async-std/async-tls" }
 
 [dependencies]
-futures = "0.3.4"
+futures-io = "0.3.5"
+futures-core = "0.3.5"
 rustls = "0.18.0"
 webpki = { version = "0.21.2", optional = true }
 webpki-roots = { version = "0.20.0", optional = true }
@@ -29,7 +30,8 @@ server = []
 
 [dev-dependencies]
 lazy_static = "1"
-futures-util = "0.3"
+futures-executor = "0.3.5"
+futures-util = { version = "0.3.5", features = ["io"] }
 async-std = { version = "1.0", features = ["unstable"] }
 
 [[test]]

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -1,7 +1,7 @@
 use crate::common::tls_state::TlsState;
 use crate::server;
 
-use futures::io::{AsyncRead, AsyncWrite};
+use futures_io::{AsyncRead, AsyncWrite};
 use rustls::{ServerConfig, ServerSession};
 use std::future::Future;
 use std::io;

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,8 @@
 
 use crate::common::tls_state::TlsState;
 use crate::rusttls::stream::Stream;
-use futures::io::{AsyncRead, AsyncWrite};
+use futures_core::ready;
+use futures_io::{AsyncRead, AsyncWrite};
 use rustls::ClientSession;
 use std::future::Future;
 use std::pin::Pin;
@@ -58,11 +59,11 @@ where
             let mut stream = Stream::new(io, session).set_eof(eof);
 
             if stream.session.is_handshaking() {
-                futures::ready!(stream.complete_io(cx))?;
+                ready!(stream.complete_io(cx))?;
             }
 
             if stream.session.wants_write() {
-                futures::ready!(stream.complete_io(cx))?;
+                ready!(stream.complete_io(cx))?;
             }
         }
 
@@ -95,14 +96,13 @@ where
 
                 // complete handshake
                 if stream.session.is_handshaking() {
-                    futures::ready!(stream.complete_io(cx))?;
+                    ready!(stream.complete_io(cx))?;
                 }
 
                 // write early data (fallback)
                 if !stream.session.is_early_data_accepted() {
                     while *pos < data.len() {
-                        let len =
-                            futures::ready!(stream.as_mut_pin().poll_write(cx, &data[*pos..]))?;
+                        let len = ready!(stream.as_mut_pin().poll_write(cx, &data[*pos..]))?;
                         *pos += len;
                     }
                 }
@@ -176,14 +176,13 @@ where
 
                 // complete handshake
                 if stream.session.is_handshaking() {
-                    futures::ready!(stream.complete_io(cx))?;
+                    ready!(stream.complete_io(cx))?;
                 }
 
                 // write early data (fallback)
                 if !stream.session.is_early_data_accepted() {
                     while *pos < data.len() {
-                        let len =
-                            futures::ready!(stream.as_mut_pin().poll_write(cx, &data[*pos..]))?;
+                        let len = ready!(stream.as_mut_pin().poll_write(cx, &data[*pos..]))?;
                         *pos += len;
                     }
                 }

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -2,7 +2,7 @@ use crate::common::tls_state::TlsState;
 
 use crate::client;
 
-use futures::io::{AsyncRead, AsyncWrite};
+use futures_io::{AsyncRead, AsyncWrite};
 use rustls::{ClientConfig, ClientSession};
 use std::future::Future;
 use std::io;

--- a/src/rusttls/stream.rs
+++ b/src/rusttls/stream.rs
@@ -1,4 +1,5 @@
-use futures::io::{AsyncRead, AsyncWrite};
+use futures_core::ready;
+use futures_io::{AsyncRead, AsyncWrite};
 use rustls::Session;
 use std::io::{self, Read, Write};
 use std::marker::Unpin;
@@ -242,7 +243,7 @@ impl<'a, IO: AsyncRead + AsyncWrite + Unpin, S: Session> AsyncWrite for Stream<'
 
         this.session.flush()?;
         while this.session.wants_write() {
-            futures::ready!(this.complete_inner_io(cx, Focus::Writable))?;
+            ready!(this.complete_inner_io(cx, Focus::Writable))?;
         }
         Pin::new(&mut this.io).poll_flush(cx)
     }
@@ -251,7 +252,7 @@ impl<'a, IO: AsyncRead + AsyncWrite + Unpin, S: Session> AsyncWrite for Stream<'
         let this = self.get_mut();
 
         while this.session.wants_write() {
-            futures::ready!(this.complete_inner_io(cx, Focus::Writable))?;
+            ready!(this.complete_inner_io(cx, Focus::Writable))?;
         }
         Pin::new(&mut this.io).poll_close(cx)
     }

--- a/src/rusttls/test_stream.rs
+++ b/src/rusttls/test_stream.rs
@@ -1,8 +1,9 @@
 use super::Stream;
-use futures::executor;
-use futures::io::{AsyncRead, AsyncWrite};
-use futures::prelude::*;
-use futures::task::{noop_waker_ref, Context};
+use futures_executor::block_on;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::io::{AsyncReadExt, AsyncWriteExt};
+use futures_util::task::{noop_waker_ref, Context};
+use futures_util::{future, ready};
 use rustls::internal::pemfile::{certs, rsa_private_keys};
 use rustls::{ClientConfig, ClientSession, NoClientAuth, ServerConfig, ServerSession, Session};
 use std::io::{self, BufReader, Cursor, Read, Write};
@@ -105,7 +106,7 @@ fn stream_good() -> io::Result<()> {
         Ok(()) as io::Result<()>
     };
 
-    executor::block_on(fut)
+    block_on(fut)
 }
 
 #[test]
@@ -137,7 +138,7 @@ fn stream_bad() -> io::Result<()> {
         Ok(()) as io::Result<()>
     };
 
-    executor::block_on(fut)
+    block_on(fut)
 }
 
 #[test]
@@ -162,7 +163,7 @@ fn stream_handshake() -> io::Result<()> {
         Ok(()) as io::Result<()>
     };
 
-    executor::block_on(fut)
+    block_on(fut)
 }
 
 #[test]
@@ -183,7 +184,7 @@ fn stream_handshake_eof() -> io::Result<()> {
         Ok(()) as io::Result<()>
     };
 
-    executor::block_on(fut)
+    block_on(fut)
 }
 
 #[test]
@@ -202,7 +203,7 @@ fn stream_eof() -> io::Result<()> {
         Ok(()) as io::Result<()>
     };
 
-    executor::block_on(fut)
+    block_on(fut)
 }
 
 fn make_pair() -> (ServerSession, ClientSession) {
@@ -234,11 +235,11 @@ fn do_handshake(
     let mut stream = Stream::new(&mut good, client);
 
     if stream.session.is_handshaking() {
-        futures::ready!(stream.complete_io(cx))?;
+        ready!(stream.complete_io(cx))?;
     }
 
     if stream.session.wants_write() {
-        futures::ready!(stream.complete_io(cx))?;
+        ready!(stream.complete_io(cx))?;
     }
 
     Poll::Ready(Ok(()))

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,7 +3,8 @@
 use crate::common::tls_state::TlsState;
 use crate::rusttls::stream::Stream;
 
-use futures::io::{AsyncRead, AsyncWrite};
+use futures_core::ready;
+use futures_io::{AsyncRead, AsyncWrite};
 use rustls::ServerSession;
 use std::future::Future;
 use std::pin::Pin;
@@ -42,11 +43,11 @@ where
             let mut stream = Stream::new(io, session).set_eof(eof);
 
             if stream.session.is_handshaking() {
-                futures::ready!(stream.complete_io(cx))?;
+                ready!(stream.complete_io(cx))?;
             }
 
             if stream.session.wants_write() {
-                futures::ready!(stream.complete_io(cx))?;
+                ready!(stream.complete_io(cx))?;
             }
         }
 

--- a/src/test_0rtt.rs
+++ b/src/test_0rtt.rs
@@ -1,8 +1,8 @@
 use crate::{client::TlsStream, TlsConnector};
 use async_std::net::TcpStream;
 use async_std::sync::Arc;
-use futures::executor;
-use futures::prelude::*;
+use futures_executor::block_on;
+use futures_util::io::{AsyncReadExt, AsyncWriteExt};
 use rustls::ClientConfig;
 use std::io;
 use std::net::ToSocketAddrs;
@@ -36,10 +36,10 @@ fn test_0rtt() {
     let config = Arc::new(config);
     let domain = "mozilla-modern.badssl.com";
 
-    let (_, output) = executor::block_on(get(config.clone(), domain, false)).unwrap();
+    let (_, output) = block_on(get(config.clone(), domain, false)).unwrap();
     assert!(output.contains("<title>mozilla-modern.badssl.com</title>"));
 
-    let (io, output) = executor::block_on(get(config.clone(), domain, true)).unwrap();
+    let (io, output) = block_on(get(config.clone(), domain, true)).unwrap();
     assert!(output.contains("<title>mozilla-modern.badssl.com</title>"));
 
     assert_eq!(io.early_data.0, 0);

--- a/tests/google.rs
+++ b/tests/google.rs
@@ -1,7 +1,7 @@
 use async_std::net::TcpStream;
 use async_std::task;
 use async_tls::TlsConnector;
-use futures::prelude::*;
+use futures_util::io::{AsyncReadExt, AsyncWriteExt};
 
 #[test]
 fn fetch_google() -> std::io::Result<()> {


### PR DESCRIPTION
This lets downstream crates avoid building the unused `futures-channel`, `futures-executor`, `futures-sink`, `futures-task`, and `futures-util` crates and their dependencies.

This reduces the total number of transitive dependencies from 47 to 18.