### PR TITLE
Make session public in TlsStream

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,7 @@ use rustls::Session;
 #[derive(Debug)]
 pub struct TlsStream<IO> {
     pub(crate) io: IO,
-    pub(crate) session: ClientSession,
+    pub session: ClientSession,
     pub(crate) state: TlsState,
 
     #[cfg(feature = "early-data")]

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,7 +18,7 @@ use rustls::Session;
 #[derive(Debug)]
 pub struct TlsStream<IO> {
     pub(crate) io: IO,
-    pub(crate) session: ServerSession,
+    pub session: ServerSession,
     pub(crate) state: TlsState,
 }
 


### PR DESCRIPTION
Some very important data provided by `Session` are currently hidden (e.g. which protocol was selected by the handshake). 

Ref: https://github.com/async-rs/async-tls/issues/30