### PR TITLE
Add get_sni_hostname to server::TlsStream

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -22,6 +22,13 @@ pub struct TlsStream<IO> {
     pub(crate) state: TlsState,
 }
 
+impl<IO> TlsStream<IO> {
+    /// Retrieves the SNI hostname, if any, used to select the certificate and private key.
+    pub fn get_sni_hostname(&self) -> Option<&str> {
+        self.session.get_sni_hostname()
+    }
+}
+
 pub(crate) enum MidHandshake<IO> {
     Handshaking(TlsStream<IO>),
     End,


### PR DESCRIPTION
The implementation simply passes through to `ServerSession.get_sni_hostname`.

There are protocols that reccommend or require the use of Server Name Identification. This change does not expose the inner tls implementation, but it does borrow the name from `rustls`.