### PR TITLE
Attempt to port to rustls 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,10 @@ appveyor = { repository = "async-std/async-tls" }
 [dependencies]
 futures-io = "0.3.5"
 futures-core = "0.3.5"
-rustls = "0.18.0"
-webpki = { version = "0.21.2", optional = true }
-webpki-roots = { version = "0.20.0", optional = true }
+rustls = "0.20.4"
+rustls-pemfile = "0.3"
+webpki = { version = "0.22.0", optional = true }
+webpki-roots = { version = "0.22.3", optional = true }
 
 [features]
 default = ["client", "server"]

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -3,13 +3,13 @@ use crate::common::tls_state::TlsState;
 use crate::client;
 
 use futures_io::{AsyncRead, AsyncWrite};
-use rustls::{ClientConfig, ClientSession};
+use rustls::{ClientConfig, ClientConnection, ServerName, RootCertStore, OwnedTrustAnchor};
+use std::convert::TryFrom;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use webpki::DNSNameRef;
 
 /// The TLS connecting part. The acceptor drives
 /// the client side of the TLS handshake process. It works
@@ -64,10 +64,23 @@ impl From<ClientConfig> for TlsConnector {
 
 impl Default for TlsConnector {
     fn default() -> Self {
-        let mut config = ClientConfig::new();
-        config
-            .root_store
-            .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+        let mut root_certs = RootCertStore::empty();
+        root_certs.add_server_trust_anchors(
+            webpki_roots::TLS_SERVER_ROOTS
+                .0
+                .iter()
+                .map(|ta| {
+                    OwnedTrustAnchor::from_subject_spki_name_constraints(
+                        ta.subject,
+                        ta.spki,
+                        ta.name_constraints,
+                    )
+                }),
+        );
+        let config = ClientConfig::builder()
+            .with_safe_defaults()
+            .with_root_certificates(root_certs)
+            .with_no_client_auth();
         Arc::new(config).into()
     }
 }
@@ -102,14 +115,14 @@ impl TlsConnector {
         self.connect_with(domain, stream, |_| ())
     }
 
-    // NOTE: Currently private, exposing ClientSession exposes rusttls
+    // NOTE: Currently private, exposing ClientConnection exposes rusttls
     // Early data should be exposed differently
     fn connect_with<'a, IO, F>(&self, domain: impl AsRef<str>, stream: IO, f: F) -> Connect<IO>
     where
         IO: AsyncRead + AsyncWrite + Unpin,
-        F: FnOnce(&mut ClientSession),
+        F: FnOnce(&mut ClientConnection),
     {
-        let domain = match DNSNameRef::try_from_ascii_str(domain.as_ref()) {
+        let domain = match ServerName::try_from(domain.as_ref()) {
             Ok(domain) => domain,
             Err(_) => {
                 return Connect(ConnectInner::Error(Some(io::Error::new(
@@ -119,7 +132,16 @@ impl TlsConnector {
             }
         };
 
-        let mut session = ClientSession::new(&self.inner, domain);
+        let mut session = match ClientConnection::new(self.inner.clone(), domain) {
+            Ok(session) => session,
+            Err(_) => {
+                return Connect(ConnectInner::Error(Some(io::Error::new(
+                    io::ErrorKind::Other,
+                    "invalid connection",
+                ))))
+            }
+        };
+
         f(&mut session);
 
         #[cfg(not(feature = "early-data"))]

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -3,7 +3,7 @@ use crate::common::tls_state::TlsState;
 use crate::client;
 
 use futures_io::{AsyncRead, AsyncWrite};
-use rustls::{ClientConfig, ClientConnection, ServerName, RootCertStore, OwnedTrustAnchor};
+use rustls::{ClientConfig, ClientConnection, OwnedTrustAnchor, RootCertStore, ServerName};
 use std::convert::TryFrom;
 use std::future::Future;
 use std::io;
@@ -65,18 +65,13 @@ impl From<ClientConfig> for TlsConnector {
 impl Default for TlsConnector {
     fn default() -> Self {
         let mut root_certs = RootCertStore::empty();
-        root_certs.add_server_trust_anchors(
-            webpki_roots::TLS_SERVER_ROOTS
-                .0
-                .iter()
-                .map(|ta| {
-                    OwnedTrustAnchor::from_subject_spki_name_constraints(
-                        ta.subject,
-                        ta.spki,
-                        ta.name_constraints,
-                    )
-                }),
-        );
+        root_certs.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+            OwnedTrustAnchor::from_subject_spki_name_constraints(
+                ta.subject,
+                ta.spki,
+                ta.name_constraints,
+            )
+        }));
         let config = ClientConfig::builder()
             .with_safe_defaults()
             .with_root_certificates(root_certs)

--- a/src/rusttls/stream.rs
+++ b/src/rusttls/stream.rs
@@ -203,9 +203,7 @@ impl<'a, IO: AsyncRead + AsyncWrite + Unpin, D: Unpin> AsyncRead for Stream<'a, 
         let mut reader = this.conn.reader();
         match reader.read(buf) {
             Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => Poll::Pending,
-            result => {
-                Poll::Ready(result)
-            },
+            result => Poll::Ready(result),
         }
     }
 }

--- a/src/rusttls/test_stream.rs
+++ b/src/rusttls/test_stream.rs
@@ -4,8 +4,11 @@ use futures_io::{AsyncRead, AsyncWrite};
 use futures_util::io::{AsyncReadExt, AsyncWriteExt};
 use futures_util::task::{noop_waker_ref, Context};
 use futures_util::{future, ready};
+use rustls::{
+    Certificate, ClientConfig, ClientConnection, ConnectionCommon, PrivateKey, RootCertStore,
+    ServerConfig, ServerConnection, ServerName,
+};
 use rustls_pemfile::{certs, rsa_private_keys};
-use rustls::{ClientConfig, ClientConnection, ServerConfig, ServerConnection, ConnectionCommon, Certificate, PrivateKey, ServerName, RootCertStore};
 use std::convert::TryFrom;
 use std::io::{self, BufReader, Cursor, Read, Write};
 use std::pin::Pin;

--- a/src/rusttls/test_stream.rs
+++ b/src/rusttls/test_stream.rs
@@ -82,7 +82,7 @@ impl AsyncWrite for Bad {
 
 #[test]
 fn stream_good() -> io::Result<()> {
-    const FILE: &'static [u8] = include_bytes!("../../README.md");
+    const FILE: &[u8] = include_bytes!("../../README.md");
 
     let fut = async {
         let (mut server, mut client) = make_pair();

--- a/src/rusttls/test_stream.rs
+++ b/src/rusttls/test_stream.rs
@@ -4,17 +4,17 @@ use futures_io::{AsyncRead, AsyncWrite};
 use futures_util::io::{AsyncReadExt, AsyncWriteExt};
 use futures_util::task::{noop_waker_ref, Context};
 use futures_util::{future, ready};
-use rustls::internal::pemfile::{certs, rsa_private_keys};
-use rustls::{ClientConfig, ClientSession, NoClientAuth, ServerConfig, ServerSession, Session};
+use rustls_pemfile::{certs, rsa_private_keys};
+use rustls::{ClientConfig, ClientConnection, ServerConfig, ServerConnection, ConnectionCommon, Certificate, PrivateKey, ServerName, RootCertStore};
+use std::convert::TryFrom;
 use std::io::{self, BufReader, Cursor, Read, Write};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Poll;
-use webpki::DNSNameRef;
 
-struct Good<'a>(&'a mut dyn Session);
+struct Good<'a, D>(&'a mut ConnectionCommon<D>);
 
-impl<'a> AsyncRead for Good<'a> {
+impl<'a, D> AsyncRead for Good<'a, D> {
     fn poll_read(
         mut self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
@@ -24,7 +24,7 @@ impl<'a> AsyncRead for Good<'a> {
     }
 }
 
-impl<'a> AsyncWrite for Good<'a> {
+impl<'a, D> AsyncWrite for Good<'a, D> {
     fn poll_write(
         mut self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
@@ -87,7 +87,7 @@ fn stream_good() -> io::Result<()> {
     let fut = async {
         let (mut server, mut client) = make_pair();
         future::poll_fn(|cx| do_handshake(&mut client, &mut server, cx)).await?;
-        io::copy(&mut Cursor::new(FILE), &mut server)?;
+        io::copy(&mut Cursor::new(FILE), &mut server.writer())?;
 
         {
             let mut good = Good(&mut server);
@@ -100,7 +100,7 @@ fn stream_good() -> io::Result<()> {
         }
 
         let mut buf = String::new();
-        server.read_to_string(&mut buf)?;
+        server.reader().read_to_string(&mut buf)?;
         assert_eq!(buf, "Hello World!");
 
         Ok(()) as io::Result<()>
@@ -114,7 +114,7 @@ fn stream_bad() -> io::Result<()> {
     let fut = async {
         let (mut server, mut client) = make_pair();
         future::poll_fn(|cx| do_handshake(&mut client, &mut server, cx)).await?;
-        client.set_buffer_limit(1024);
+        client.set_buffer_limit(Some(1024));
 
         let mut bad = Bad(true);
         let mut stream = Stream::new(&mut bad, &mut client);
@@ -206,39 +206,49 @@ fn stream_eof() -> io::Result<()> {
     block_on(fut)
 }
 
-fn make_pair() -> (ServerSession, ClientSession) {
+fn make_pair() -> (ServerConnection, ClientConnection) {
     const CERT: &str = include_str!("../../tests/end.cert");
     const CHAIN: &str = include_str!("../../tests/end.chain");
     const RSA: &str = include_str!("../../tests/end.rsa");
 
     let cert = certs(&mut BufReader::new(Cursor::new(CERT))).unwrap();
+    let cert = cert.into_iter().map(Certificate).collect();
     let mut keys = rsa_private_keys(&mut BufReader::new(Cursor::new(RSA))).unwrap();
-    let mut sconfig = ServerConfig::new(NoClientAuth::new());
-    sconfig.set_single_cert(cert, keys.pop().unwrap()).unwrap();
-    let server = ServerSession::new(&Arc::new(sconfig));
+    let key = PrivateKey(keys.pop().unwrap());
+    let sconfig = ServerConfig::builder()
+        .with_safe_defaults()
+        .with_no_client_auth()
+        .with_single_cert(cert, key)
+        .unwrap();
+    let server = ServerConnection::new(Arc::new(sconfig));
 
-    let domain = DNSNameRef::try_from_ascii_str("localhost").unwrap();
-    let mut cconfig = ClientConfig::new();
-    let mut chain = BufReader::new(Cursor::new(CHAIN));
-    cconfig.root_store.add_pem_file(&mut chain).unwrap();
-    let client = ClientSession::new(&Arc::new(cconfig), domain);
+    let domain = ServerName::try_from("localhost").unwrap();
+    let mut root_store = RootCertStore::empty();
+    let chain = certs(&mut BufReader::new(Cursor::new(CHAIN))).unwrap();
+    let (added, ignored) = root_store.add_parsable_certificates(&chain);
+    assert!(added >= 1 && ignored == 0);
+    let cconfig = ClientConfig::builder()
+        .with_safe_defaults()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    let client = ClientConnection::new(Arc::new(cconfig), domain);
 
-    (server, client)
+    (server.unwrap(), client.unwrap())
 }
 
 fn do_handshake(
-    client: &mut ClientSession,
-    server: &mut ServerSession,
+    client: &mut ClientConnection,
+    server: &mut ServerConnection,
     cx: &mut Context<'_>,
 ) -> Poll<io::Result<()>> {
     let mut good = Good(server);
     let mut stream = Stream::new(&mut good, client);
 
-    if stream.session.is_handshaking() {
+    if stream.conn.is_handshaking() {
         ready!(stream.complete_io(cx))?;
     }
 
-    if stream.session.wants_write() {
+    if stream.conn.wants_write() {
         ready!(stream.complete_io(cx))?;
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -66,8 +66,7 @@ where
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
         let this = self.get_mut();
-        let mut stream =
-            Stream::new(&mut this.io, &mut this.conn).set_eof(!this.state.readable());
+        let mut stream = Stream::new(&mut this.io, &mut this.conn).set_eof(!this.state.readable());
 
         match this.state {
             TlsState::Stream | TlsState::WriteShutdown => {
@@ -106,15 +105,13 @@ where
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         let this = self.get_mut();
-        let mut stream =
-            Stream::new(&mut this.io, &mut this.conn).set_eof(!this.state.readable());
+        let mut stream = Stream::new(&mut this.io, &mut this.conn).set_eof(!this.state.readable());
         stream.as_mut_pin().poll_write(cx, buf)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let this = self.get_mut();
-        let mut stream =
-            Stream::new(&mut this.io, &mut this.conn).set_eof(!this.state.readable());
+        let mut stream = Stream::new(&mut this.io, &mut this.conn).set_eof(!this.state.readable());
         stream.as_mut_pin().poll_flush(cx)
     }
 
@@ -125,8 +122,7 @@ where
         }
 
         let this = self.get_mut();
-        let mut stream =
-            Stream::new(&mut this.io, &mut this.conn).set_eof(!this.state.readable());
+        let mut stream = Stream::new(&mut this.io, &mut this.conn).set_eof(!this.state.readable());
         stream.as_mut_pin().poll_close(cx)
     }
 }

--- a/src/test_0rtt.rs
+++ b/src/test_0rtt.rs
@@ -3,7 +3,7 @@ use async_std::net::TcpStream;
 use async_std::sync::Arc;
 use futures_executor::block_on;
 use futures_util::io::{AsyncReadExt, AsyncWriteExt};
-use rustls::ClientConfig;
+use rustls::{ClientConfig, RootCertStore, OwnedTrustAnchor};
 use std::io;
 use std::net::ToSocketAddrs;
 
@@ -28,10 +28,24 @@ async fn get(
 
 #[test]
 fn test_0rtt() {
-    let mut config = ClientConfig::new();
-    config
-        .root_store
-        .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let mut root_certs = RootCertStore::empty();
+    root_certs.add_server_trust_anchors(
+        webpki_roots::TLS_SERVER_ROOTS
+            .0
+            .iter()
+            .map(|ta| {
+                OwnedTrustAnchor::from_subject_spki_name_constraints(
+                    ta.subject,
+                    ta.spki,
+                    ta.name_constraints,
+                )
+            }),
+    );
+    let config = ClientConfig::builder()
+        .with_safe_defaults()
+        .with_root_certificates(root_certs)
+        .with_no_client_auth();
+
     config.enable_early_data = true;
     let config = Arc::new(config);
     let domain = "mozilla-modern.badssl.com";

--- a/src/test_0rtt.rs
+++ b/src/test_0rtt.rs
@@ -3,7 +3,7 @@ use async_std::net::TcpStream;
 use async_std::sync::Arc;
 use futures_executor::block_on;
 use futures_util::io::{AsyncReadExt, AsyncWriteExt};
-use rustls::{ClientConfig, RootCertStore, OwnedTrustAnchor};
+use rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore};
 use std::io;
 use std::net::ToSocketAddrs;
 
@@ -29,18 +29,13 @@ async fn get(
 #[test]
 fn test_0rtt() {
     let mut root_certs = RootCertStore::empty();
-    root_certs.add_server_trust_anchors(
-        webpki_roots::TLS_SERVER_ROOTS
-            .0
-            .iter()
-            .map(|ta| {
-                OwnedTrustAnchor::from_subject_spki_name_constraints(
-                    ta.subject,
-                    ta.spki,
-                    ta.name_constraints,
-                )
-            }),
-    );
+    root_certs.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+        OwnedTrustAnchor::from_subject_spki_name_constraints(
+            ta.subject,
+            ta.spki,
+            ta.name_constraints,
+        )
+    }));
     let config = ClientConfig::builder()
         .with_safe_defaults()
         .with_root_certificates(root_certs)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -61,7 +61,7 @@ fn start_server() -> &'static (SocketAddr, &'static str, &'static str) {
 }
 
 async fn start_client(addr: SocketAddr, domain: &str, config: Arc<ClientConfig>) -> io::Result<()> {
-    const FILE: &'static [u8] = include_bytes!("../README.md");
+    const FILE: &[u8] = include_bytes!("../README.md");
 
     let config = TlsConnector::from(config);
     let mut buf = vec![0; FILE.len()];
@@ -88,7 +88,7 @@ fn pass() {
         .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
-    task::block_on(start_client(addr.clone(), domain, Arc::new(config))).unwrap();
+    task::block_on(start_client(*addr, domain, Arc::new(config))).unwrap();
 }
 
 #[test]
@@ -105,5 +105,5 @@ fn fail() {
     let config = Arc::new(config);
 
     assert_ne!(domain, &"google.com");
-    assert!(task::block_on(start_client(addr.clone(), "google.com", config)).is_err());
+    assert!(task::block_on(start_client(*addr, "google.com", config)).is_err());
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,12 +1,12 @@
+use async_std::channel::bounded;
 use async_std::io;
 use async_std::net::{TcpListener, TcpStream};
 use async_std::prelude::*;
-use async_std::channel::bounded;
 use async_std::task;
 use async_tls::{TlsAcceptor, TlsConnector};
 use lazy_static::lazy_static;
+use rustls::{Certificate, ClientConfig, PrivateKey, RootCertStore, ServerConfig};
 use rustls_pemfile::{certs, rsa_private_keys};
-use rustls::{ClientConfig, ServerConfig, Certificate, PrivateKey, RootCertStore};
 use std::io::{BufReader, Cursor};
 use std::net::SocketAddr;
 use std::sync::Arc;


### PR DESCRIPTION
Just what the title says.  Attempted to port to rustls 0.20 (should close #45) -- got (most) things compiling but tests are not happy.

```
❯ cargo test --all
   Compiling async-tls v0.10.0 (/home/ubuntu/dev/async-tls)
    Finished test [unoptimized + debuginfo] target(s) in 2.93s
     Running unittests (target/debug/deps/async_tls-739fa847c8772885)

running 5 tests
test rusttls::stream::test_stream::stream_handshake_eof ... ok
test rusttls::stream::test_stream::stream_handshake ... ok
test rusttls::stream::test_stream::stream_bad ... ok
test rusttls::stream::test_stream::stream_good ... FAILED
test rusttls::stream::test_stream::stream_eof has been running for over 60 seconds
```

Digging further, the `stream_good` test seems to have issues with handshaking, so it throws an early EOF:

```
Error: Kind(UnexpectedEof)
thread 'rusttls::stream::test_stream::stream_good' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/test/src/lib.rs:195:5
```