### PR TITLE
Replace unmaintained webpki dependency with rustls-webpki

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,13 @@ futures-io = "0.3.5"
 futures-core = "0.3.5"
 rustls = "0.21"
 rustls-pemfile = "1.0"
-webpki = { version = "0.22.0", optional = true }
+# webpki = { version = "0.22.0", optional = true }
+rustls-webpki = { version = "0.101.4", optional = true }
 webpki-roots = { version = "0.22.3", optional = true }
 
 [features]
 default = ["client", "server"]
-client = ["webpki", "webpki-roots"]
+client = ["webpki-roots"]
 early-data = []
 server = []
 

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -65,7 +65,7 @@ impl From<ClientConfig> for TlsConnector {
 impl Default for TlsConnector {
     fn default() -> Self {
         let mut root_certs = RootCertStore::empty();
-        root_certs.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+        root_certs.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
             OwnedTrustAnchor::from_subject_spki_name_constraints(
                 ta.subject,
                 ta.spki,


### PR DESCRIPTION
Fixes #53, and passes all tests (that were passed by the version before hand, which already seems broken on the "early-data" feature). This is not a breaking change, and just needs to be merged.